### PR TITLE
CGI.escape_html -> ERB::Escape.html_escape

### DIFF
--- a/lib/p2/compiler.rb
+++ b/lib/p2/compiler.rb
@@ -3,6 +3,7 @@
 require 'cgi'
 require 'sirop'
 require 'digest/md5'
+require 'erb/escape'
 
 module P2
   class TagNode
@@ -292,13 +293,13 @@ module P2
 
       if node.inner_text
         if is_static_node?(node.inner_text)
-          emit_html(node.location, CGI.escape_html(format_literal(node.inner_text)))
+          emit_html(node.location, ERB::Escape.html_escape(format_literal(node.inner_text)))
         else
           convert_to_s = !is_string_type_node?(node.inner_text)
           if convert_to_s
-            emit_html(node.location, "#\{CGI.escape_html((#{format_code(node.inner_text)}).to_s)}")
+            emit_html(node.location, "#\{ERB::Escape.html_escape((#{format_code(node.inner_text)}).to_s)}")
           else
-            emit_html(node.location, "#\{CGI.escape_html(#{format_code(node.inner_text)})}")
+            emit_html(node.location, "#\{ERB::Escape.html_escape(#{format_code(node.inner_text)})}")
           end
         end
       end
@@ -345,9 +346,9 @@ module P2
       first_arg = args.first
       if args.length == 1
         if is_static_node?(first_arg)
-          emit_html(node.location, CGI.escape_html(format_literal(first_arg)))
+          emit_html(node.location, ERB::Escape.html_escape(format_literal(first_arg)))
         else
-          emit_html(node.location, "#\{CGI.escape_html(#{format_code(first_arg)}.to_s)}")
+          emit_html(node.location, "#\{ERB::Escape.html_escape(#{format_code(first_arg)}.to_s)}")
         end
       else
         raise "Don't know how to compile #{node}"


### PR DESCRIPTION
Using ruby's built in `ERB::Escape.html_escape` over `CGI.escape_html` yields better performance when I run the benchmarks.

```
Warming up --------------------------------------
                  p2    54.466k i/100ms
               phlex    15.967k i/100ms
                 erb    24.702k i/100ms
Calculating -------------------------------------
                  p2    561.970k (± 3.3%) i/s -      2.832M in   5.045866s
               phlex    158.617k (± 1.9%) i/s -    798.350k in   5.034935s
                 erb    218.755k (± 7.5%) i/s -      1.112M in   5.109313s

Comparison:
                  p2:   561970.3 i/s
                 erb:   218755.1 i/s - 2.57x  slower
               phlex:   158617.3 i/s - 3.54x  slower
``` 